### PR TITLE
feat: 단축 URL을 찾을 수 없는 예외 처리

### DIFF
--- a/src/main/java/com/study/short_url_service/application/ShortUrlService.java
+++ b/src/main/java/com/study/short_url_service/application/ShortUrlService.java
@@ -1,6 +1,7 @@
 package com.study.short_url_service.application;
 
 import com.study.short_url_service.domain.ShortUrl;
+import com.study.short_url_service.domain.ShortUrlNotFoundException;
 import com.study.short_url_service.domain.ShortUrlRepository;
 import com.study.short_url_service.presentation.ShortUrlCreationRequestDTO;
 import com.study.short_url_service.presentation.ShortUrlCreationResponseDTO;
@@ -33,6 +34,11 @@ public class ShortUrlService {
 
     public String getOriginalUrl(String shortUrlKey) {
         ShortUrl shortUrl = shortUrlRepository.find(shortUrlKey);
+
+        if (null == shortUrl) {
+            throw new ShortUrlNotFoundException();
+        }
+
         String originalUrl = shortUrl.getOriginalUrl();
 
         shortUrl.increaseRedirectCount();
@@ -44,6 +50,10 @@ public class ShortUrlService {
 
     public ShortUrlDTO fetchShortUrlInformation(String shortUrlKey) {
         ShortUrl shortUrl = shortUrlRepository.find(shortUrlKey);
+
+        if (null == shortUrl) {
+            throw new ShortUrlNotFoundException();
+        }
 
         ShortUrlDTO shortUrlDTO = new ShortUrlDTO(shortUrl);
 

--- a/src/main/java/com/study/short_url_service/domain/ShortUrlNotFoundException.java
+++ b/src/main/java/com/study/short_url_service/domain/ShortUrlNotFoundException.java
@@ -1,0 +1,4 @@
+package com.study.short_url_service.domain;
+
+public class ShortUrlNotFoundException extends RuntimeException {
+}

--- a/src/main/java/com/study/short_url_service/presentation/GlobalExceptionHandler.java
+++ b/src/main/java/com/study/short_url_service/presentation/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.study.short_url_service.presentation;
+
+import com.study.short_url_service.domain.ShortUrlNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ShortUrlNotFoundException.class)
+    public ResponseEntity<String> handleShortUrlNotFoundException(
+            ShortUrlNotFoundException ex
+    ) {
+        return new ResponseEntity<>("단축 URL을 찾지 못했습니다.", HttpStatus.NOT_FOUND);
+    }
+}


### PR DESCRIPTION
- 전역 예외 핸들러 추가
- 단축 URL을 찾을 수 없는 경우 404 Not Found 상태 코드와 함께 "단축 URL을 찾지 못했습니다." 응답 반환