### PR TITLE
feat: 생성 가능한 단축 URL 자원이 부족한 예외 처리

### DIFF
--- a/src/main/java/com/study/short_url_service/application/ShortUrlService.java
+++ b/src/main/java/com/study/short_url_service/application/ShortUrlService.java
@@ -1,5 +1,6 @@
 package com.study.short_url_service.application;
 
+import com.study.short_url_service.domain.LackOfShortUrlKeyException;
 import com.study.short_url_service.domain.ShortUrl;
 import com.study.short_url_service.domain.ShortUrlNotFoundException;
 import com.study.short_url_service.domain.ShortUrlRepository;
@@ -22,7 +23,7 @@ public class ShortUrlService {
             ShortUrlCreationRequestDTO shortUrlCreationRequestDTO
     ) {
         String originalUrl = shortUrlCreationRequestDTO.getOriginalUrl();
-        String shortUrlKey = ShortUrl.generateShortUrlKey();
+        String shortUrlKey = generateUniqueShortUrlKey();
         ShortUrl shortUrl = new ShortUrl(originalUrl, shortUrlKey);
 
         shortUrlRepository.save(shortUrl);
@@ -30,6 +31,21 @@ public class ShortUrlService {
         ShortUrlCreationResponseDTO shortUrlCreationResponseDTO = new ShortUrlCreationResponseDTO(shortUrl);
 
         return shortUrlCreationResponseDTO;
+    }
+
+    private String generateUniqueShortUrlKey() {
+        final int MAX_RETRY_COUNT = 5;
+
+        for (int count = 0; count < MAX_RETRY_COUNT; count++) {
+            String shortUrlKey = ShortUrl.generateShortUrlKey();
+            ShortUrl shortUrl = shortUrlRepository.find(shortUrlKey);
+
+            if (null == shortUrl) {
+                return shortUrlKey;
+            }
+        }
+
+        throw new LackOfShortUrlKeyException();
     }
 
     public String getOriginalUrl(String shortUrlKey) {

--- a/src/main/java/com/study/short_url_service/domain/LackOfShortUrlKeyException.java
+++ b/src/main/java/com/study/short_url_service/domain/LackOfShortUrlKeyException.java
@@ -1,0 +1,4 @@
+package com.study.short_url_service.domain;
+
+public class LackOfShortUrlKeyException extends RuntimeException {
+}

--- a/src/main/java/com/study/short_url_service/presentation/GlobalExceptionHandler.java
+++ b/src/main/java/com/study/short_url_service/presentation/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.study.short_url_service.presentation;
 
+import com.study.short_url_service.domain.LackOfShortUrlKeyException;
 import com.study.short_url_service.domain.ShortUrlNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,5 +15,12 @@ public class GlobalExceptionHandler {
             ShortUrlNotFoundException ex
     ) {
         return new ResponseEntity<>("단축 URL을 찾지 못했습니다.", HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(LackOfShortUrlKeyException.class)
+    public ResponseEntity<String> handleLackOfShortUrlKeyException(
+            LackOfShortUrlKeyException ex
+    ) {
+        return new ResponseEntity<>("단축 URL 자원이 부족합니다.", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }


### PR DESCRIPTION
- 랜덤으로 생성한 단축 URL key가 이미 존재하는 경우 최대 5회까지 생성 시도 후 500 Internal Server Error 상태 코드와 함께 "단축 URL 자원이 부족합니다." 응답 반환